### PR TITLE
Fix language paramater syntax to fix build.

### DIFF
--- a/src/Data/Boolean.hs
+++ b/src/Data/Boolean.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FunctionalDependencies
-           , UndecidableInstances, ScopedTypeVariables
-  #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FunctionalDependencies,
+             UndecidableInstances, ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies, FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 


### PR DESCRIPTION
`./Setup.hls build` wasn't working for me without this, and it seems like a relatively minor change.

Disclaimer: I don't know anything about Haskell.
