### PR TITLE
Add impliesB, defaults for true and notB

### DIFF
--- a/src/Data/Boolean.hs
+++ b/src/Data/Boolean.hs
@@ -55,6 +55,11 @@ class Boolean b where
   true, false  :: b
   notB         :: b -> b
   (&&*), (||*) :: b -> b -> b
+  impliesB     :: b -> b -> b
+
+  true = notB false
+  notB x = impliesB x false
+  {-# MINIMAL false, (&&*), (||*), impliesB #-}
 
 instance Boolean Bool where
   true  = True
@@ -62,6 +67,7 @@ instance Boolean Bool where
   notB  = not
   (&&*) = (&&)
   (||*) = (||)
+  impliesB x y = if x then y else True
 
 -- | 'BooleanOf' computed the boolean analog of a specific type.
 type family BooleanOf a
@@ -197,6 +203,7 @@ instance Boolean bool => Boolean (z -> bool) where
   notB  = fmap notB
   (&&*) = liftA2 (&&*)
   (||*) = liftA2 (||*)
+  impliesB = liftA2 impliesB
 
 instance IfB a => IfB (z -> a) where
   ifB = cond


### PR DESCRIPTION
When writing the defaults, I stuck to (at most) minimal logic. Unfortunately, this means I can't write a default, and the new class would break old code. It's quite a downside, but the lack of `implies` (or a symbolic version) in the Prelude is a bit annoying by itself.