### PR TITLE
AMP compatibility

### DIFF
--- a/src/Data/Boolean.hs
+++ b/src/Data/Boolean.hs
@@ -40,6 +40,9 @@ module Data.Boolean
   , guardedB, caseB
   ) where
 
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<*))
+#endif
 import Data.Monoid (Monoid,mempty)
 import Control.Applicative (Applicative(pure),liftA2,liftA3)
 

--- a/src/Data/Boolean/Overload.hs
+++ b/src/Data/Boolean/Overload.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 
 ----------------------------------------------------------------------
@@ -32,6 +33,9 @@ import Prelude hiding
     (==), (/=), 
     (<), (>), (<=), (>=),
     min, max
+#if MIN_VERSION_base(4,8,0)
+    , (<*)
+#endif
   )
 
 (&&) :: Boolean a => a -> a -> a


### PR DESCRIPTION
(<*) is now exported from Prelude, hide it.
