### PR TITLE
Data.Boolean.Overload lacks fixity declarations

### DIFF
--- a/src/Data/Boolean/Overload.hs
+++ b/src/Data/Boolean/Overload.hs
@@ -38,6 +38,10 @@ import Prelude hiding
 #endif
   )
 
+infix  4  ==, /=, <, <=, >=, >
+infixr 3 &&
+infixr 2 ||
+
 (&&) :: Boolean a => a -> a -> a
 (&&) = (&&*)
 


### PR DESCRIPTION
So all the operators are infixl 9.  This just adds declarations to make them match base's.